### PR TITLE
Add basic TypeScript plugin skeleton for Obsidian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+.env
+*.log
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Frakiry
+
+This repository contains an example Obsidian plugin written in TypeScript. The plugin adds a simple command that displays a notice when executed.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Build the plugin:
+   ```bash
+   npm run build
+   ```
+3. Copy the files `manifest.json`, `dist/main.js`, and `styles.css` (if any) into your vault's `.obsidian/plugins/frakiry-plugin` directory and enable it from Obsidian's settings.
+
+Use `npm run dev` during development to automatically rebuild on changes.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "frakiry-plugin",
+  "name": "Frakiry Plugin",
+  "version": "0.1.0",
+  "minAppVersion": "1.0.0",
+  "description": "A simple Obsidian plugin written in TypeScript.",
+  "author": "Frakiry",
+  "authorUrl": "",
+  "main": "dist/main.js"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "frakiry-plugin",
+  "version": "0.1.0",
+  "description": "Example Obsidian plugin created by ChatGPT",
+  "scripts": {
+    "build": "tsc",
+    "dev": "esbuild src/main.ts --bundle --outfile dist/main.js --format=cjs --watch",
+    "test": "echo \"No tests specified\""
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "esbuild": "^0.17.19",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,17 @@
+import { Plugin, Notice } from 'obsidian';
+
+export default class FrakiryPlugin extends Plugin {
+  async onload() {
+    this.addCommand({
+      id: 'frakiry-hello',
+      name: 'Say hello',
+      callback: () => {
+        new Notice('Hello from Frakiry Plugin!');
+      }
+    });
+  }
+
+  onunload() {
+    console.log('Unloading Frakiry Plugin');
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a simple Obsidian plugin in TypeScript
- provide build scripts and TypeScript config
- document how to build and load the plugin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684000d609e8832a80b52e145b119546